### PR TITLE
Azure App Service Basic Version

### DIFF
--- a/azure/appservice/data.tf
+++ b/azure/appservice/data.tf
@@ -1,0 +1,3 @@
+data "azurerm_subscription" "primary" {}
+
+data "azurerm_client_config" "current" {}

--- a/azure/appservice/data.tf
+++ b/azure/appservice/data.tf
@@ -1,3 +1,0 @@
-data "azurerm_subscription" "primary" {}
-
-data "azurerm_client_config" "current" {}

--- a/azure/appservice/local.tf
+++ b/azure/appservice/local.tf
@@ -1,0 +1,3 @@
+locals {
+  location = "westeurope"
+}

--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -43,3 +43,10 @@ resource "azurerm_app_service" "app" {
     squad       = var.squad
   }
 }
+
+resource "azurerm_application_insights" "apm" {
+  name                = "apm-${var.project}"
+  location            = azurerm_resource_group.app.location
+  resource_group_name = azurerm_resource_group.app.name
+  application_type    = "web"
+}

--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -45,9 +45,18 @@ resource "azurerm_app_service" "app" {
   }
 }
 
-resource "azurerm_application_insights" "apm" {
+resource "azurerm_log_analytics_workspace" "apm" {
+  name                = "wsp-${var.project}"
+  location            = azurerm_resource_group.app.location
+  resource_group_name = azurerm_resource_group.app.name
+  sku                 = "Premium"
+  retention_in_days   = 90
+}
+
+resource "azurerm_application_insights" "apm" {  
   name                = "apm-${var.project}"
   location            = azurerm_resource_group.app.location
   resource_group_name = azurerm_resource_group.app.name
+  workspace_id        = azurerm_log_analytics_workspace.example.id
   application_type    = "web"
 }

--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -1,0 +1,41 @@
+resource "azurerm_resource_group" "app" {
+  name     = "rg-${var.organization}-${var.project}"
+  location = local.location
+
+  tags = {
+    country     = var.description
+    environment = var.environment
+    squad       = var.owner
+  }
+}
+
+resource "azurerm_app_service_plan" "app" {
+  name                = var.service
+  location            = azurerm_resource_group.app.location
+  resource_group_name = azurerm_resource_group.app.name
+  kind                = "Linux"
+
+  sku {
+    tier = var.sku_tier
+    size = var.sku_size
+  }
+
+  tags = {
+    country     = var.description
+    environment = var.environment
+    squad       = var.owner
+  }
+}
+
+resource "azurerm_app_service" "app" {
+  name                = "app-app-service"
+  location            = azurerm_resource_group.app.location
+  resource_group_name = azurerm_resource_group.app.name
+  app_service_plan_id = azurerm_app_service_plan.app.id
+
+  tags = {
+    country     = var.description
+    environment = var.environment
+    squad       = var.owner
+  }
+}

--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "app" {
-  name     = "rg-${var.organization}-${var.project}"
+  name     = "rg-${var.project}"
   location = local.location
 
   tags = {
@@ -10,7 +10,7 @@ resource "azurerm_resource_group" "app" {
 }
 
 resource "azurerm_app_service_plan" "app" {
-  name                = var.service
+  name                = "asp-${var.project}"
   location            = azurerm_resource_group.app.location
   resource_group_name = azurerm_resource_group.app.name
   kind                = "Linux"
@@ -28,7 +28,7 @@ resource "azurerm_app_service_plan" "app" {
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "app-app-service"
+  name                = "as-${var.project}"
   location            = azurerm_resource_group.app.location
   resource_group_name = azurerm_resource_group.app.name
   app_service_plan_id = azurerm_app_service_plan.app.id
@@ -42,11 +42,4 @@ resource "azurerm_app_service" "app" {
     environment = var.environment
     squad       = var.owner
   }
-}
-
-resource "azurerm_application_insights" "apm" {
-  name                = "apm-${var.organization}-${var.project}"
-  location            = azurerm_resource_group.app.location
-  resource_group_name = azurerm_resource_group.app.name
-  application_type    = var.app_type
 }

--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_resource_group" "app" {
   tags = {
     country     = var.country
     environment = var.environment
-    squad       = var.owner
+    squad       = var.squad
   }
 }
 
@@ -23,7 +23,7 @@ resource "azurerm_app_service_plan" "app" {
   tags = {
     country     = var.country
     environment = var.environment
-    squad       = var.owner
+    squad       = var.squad
   }
 }
 
@@ -40,6 +40,6 @@ resource "azurerm_app_service" "app" {
   tags = {
     country     = var.country
     environment = var.environment
-    squad       = var.owner
+    squad       = var.squad
   }
 }

--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -48,8 +48,7 @@ resource "azurerm_app_service" "app" {
 resource "azurerm_log_analytics_workspace" "apm" {
   name                = "wsp-${var.project}"
   location            = azurerm_resource_group.app.location
-  resource_group_name = azurerm_resource_group.app.name
-  sku                 = "Premium"
+  resource_group_name = azurerm_resource_group.app.name  
   retention_in_days   = 90
 }
 
@@ -57,6 +56,6 @@ resource "azurerm_application_insights" "apm" {
   name                = "apm-${var.project}"
   location            = azurerm_resource_group.app.location
   resource_group_name = azurerm_resource_group.app.name
-  workspace_id        = azurerm_log_analytics_workspace.apm.id
+  workspace_id        = azurerm_log_analytics_workspace.apm .id
   application_type    = "web"
 }

--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -57,6 +57,6 @@ resource "azurerm_application_insights" "apm" {
   name                = "apm-${var.project}"
   location            = azurerm_resource_group.app.location
   resource_group_name = azurerm_resource_group.app.name
-  workspace_id        = azurerm_log_analytics_workspace.example.id
+  workspace_id        = azurerm_log_analytics_workspace.apm.id
   application_type    = "web"
 }

--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -14,6 +14,7 @@ resource "azurerm_app_service_plan" "app" {
   location            = azurerm_resource_group.app.location
   resource_group_name = azurerm_resource_group.app.name
   kind                = "Linux"
+  reserved = true
 
   sku {
     tier = var.plan

--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -3,7 +3,7 @@ resource "azurerm_resource_group" "app" {
   location = local.location
 
   tags = {
-    country     = var.description
+    country     = var.country
     environment = var.environment
     squad       = var.owner
   }
@@ -16,12 +16,12 @@ resource "azurerm_app_service_plan" "app" {
   kind                = "Linux"
 
   sku {
-    tier = var.sku_tier
-    size = var.sku_size
+    tier = var.plan
+    size = var.size
   }
 
   tags = {
-    country     = var.description
+    country     = var.country
     environment = var.environment
     squad       = var.owner
   }
@@ -33,9 +33,20 @@ resource "azurerm_app_service" "app" {
   resource_group_name = azurerm_resource_group.app.name
   app_service_plan_id = azurerm_app_service_plan.app.id
 
+  site_config {
+    linux_fx_version = "DOTNETCORE|3.1"
+  }
+
   tags = {
-    country     = var.description
+    country     = var.country
     environment = var.environment
     squad       = var.owner
   }
+}
+
+resource "azurerm_application_insights" "apm" {
+  name                = "apm-${var.organization}-${var.project}"
+  location            = azurerm_resource_group.app.location
+  resource_group_name = azurerm_resource_group.app.name
+  application_type    = var.app_type
 }

--- a/azure/appservice/output.tf
+++ b/azure/appservice/output.tf
@@ -1,3 +1,7 @@
-output "resource_group" {
-  value = azurerm_resource_group.app.resource_group_name
+output "instrumentation_key" {
+  value = azurerm_application_insights.apm.instrumentation_key
+}
+
+output "app_id" {
+  value = azurerm_application_insights.app.app_id
 }

--- a/azure/appservice/output.tf
+++ b/azure/appservice/output.tf
@@ -1,0 +1,3 @@
+output "resource_group" {
+  value = azurerm_resource_group.app.resource_group_name
+}

--- a/azure/appservice/output.tf
+++ b/azure/appservice/output.tf
@@ -3,5 +3,5 @@ output "instrumentation_key" {
 }
 
 output "app_id" {
-  value = azurerm_application_insights.app.app_id
+  value = azurerm_application_insights.apm.app_id
 }

--- a/azure/appservice/terraform.tf
+++ b/azure/appservice/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.65"
+    }
+  }
+
+  required_version = ">= 0.14.6"
+}

--- a/azure/appservice/variables.tf
+++ b/azure/appservice/variables.tf
@@ -1,0 +1,57 @@
+variable "organization" {
+  description = "Organization name. It will be used by some resources."
+  type        = string
+}
+
+variable "country" {
+  description = "country"
+  type        = string
+}
+
+variable "squad" {
+  description = "squad"
+  type        = string
+}
+
+variable "environment" {
+  description = "environment"
+  type        = string
+}
+
+variable "project" {
+  description = "project name. It will be used by some resources."
+  type        = string
+}
+
+variable "service" {
+  description = "microservice or application string to be reused on resource naming"
+  type        = string
+}
+
+variable "tags" {
+  description = "Resource tags."
+  type        = map(any)
+}
+
+variable "sku_tier" {
+  description = "app service plan tier [PremiumV2 or PremiumV3]"
+  type        = string
+
+  validation {
+    condition = contains(["PremiumV2", "PremiumV3"], var.sku_tier)
+    
+
+    error_message = "sku tier must be either PremiumV2 or PremiumV3"
+  }
+}
+
+variable "sku_size" {
+  description = "app service plan instance sizetype [P1, P2 or P3]"
+  type        = string
+
+  validation {
+    condition = contains(["P1", "P2", "P3"], var.sku_size)
+
+    error_message = "sku size must be P1."
+  }
+}

--- a/azure/appservice/variables.tf
+++ b/azure/appservice/variables.tf
@@ -23,11 +23,6 @@ variable "project" {
   type        = string
 }
 
-variable "tags" {
-  description = "Resource tags."
-  type        = map(any)
-}
-
 variable "plan" {
   type = string
 }

--- a/azure/appservice/variables.tf
+++ b/azure/appservice/variables.tf
@@ -33,25 +33,10 @@ variable "tags" {
   type        = map(any)
 }
 
-variable "sku_tier" {
-  description = "app service plan tier [PremiumV2 or PremiumV3]"
-  type        = string
-
-  validation {
-    condition = contains(["PremiumV2", "PremiumV3"], var.sku_tier)
-    
-
-    error_message = "sku tier must be either PremiumV2 or PremiumV3"
-  }
+variable "plan" {
+  type = string
 }
 
-variable "sku_size" {
-  description = "app service plan instance sizetype [P1, P2 or P3]"
-  type        = string
-
-  validation {
-    condition = contains(["P1", "P2", "P3"], var.sku_size)
-
-    error_message = "sku size must be P1."
-  }
+variable "size" {
+  type = string
 }

--- a/azure/appservice/variables.tf
+++ b/azure/appservice/variables.tf
@@ -23,11 +23,6 @@ variable "project" {
   type        = string
 }
 
-variable "service" {
-  description = "microservice or application string to be reused on resource naming"
-  type        = string
-}
-
 variable "tags" {
   description = "Resource tags."
   type        = map(any)


### PR DESCRIPTION
- initial version of the app service plan templates.
- added app service basic setup
- removed the service variable since we no longer needed.
- removed the tags input variable, since we can reuse the other ones to fill the map.
- replaced the owner with squad variable.
- added resource "azurerm_application_insights" "example"
- fixed the output resource name.
- added reserved property to the app service plan since we are using Linux instances.
- added azure log analytics workspace that is the new app insights new gen.
- fixed a typo.
- removed the workspace tier and let it default.
- removed data entries.
