### PR TITLE
Feature/nmbrs 39443

### DIFF
--- a/.github/pull_request_template.yaml
+++ b/.github/pull_request_template.yaml
@@ -1,0 +1,29 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+# Description
+<!--- Describe your changes in detail -->
+
+# Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+# How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- An important detail to include is the version of the used cf-operator -->
+
+# Screenshots
+
+# Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+# Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code has security implications.
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.

--- a/azure/windows-scaleset/main.tf
+++ b/azure/windows-scaleset/main.tf
@@ -48,7 +48,8 @@ resource "azurerm_windows_virtual_machine_scale_set" "scaleset" {
     force_update_tag     = "1"
   
   settings = <<SETTINGS
-  { "commandToExecute" = "powershell -c [System.Environment]::SetEnvironmentVariable('Hangfire_BackgroundJobServerOptions_WorkerCount','10',[System.EnvironmentVariableTarget]::Machine)" }
+  { "commandToExecute": "powershell -c [System.Environment]::SetEnvironmentVariable('Hangfire_BackgroundJobServerOptions_WorkerCount','${var.max_number_threads}',[System.EnvironmentVariableTarget]::Machine);[System.Environment]::SetEnvironmentVariable('Hangfire_BackgroundJobServerOptions_Queues','${var.queue_name}',[System.EnvironmentVariableTarget]::Machine)"     
+  }
   SETTINGS
   }
   

--- a/azure/windows-scaleset/main.tf
+++ b/azure/windows-scaleset/main.tf
@@ -46,9 +46,12 @@ resource "azurerm_windows_virtual_machine_scale_set" "scaleset" {
     type                 = "CustomScriptExtension"
     type_handler_version = "1.10"
     force_update_tag     = "1"
-
-  settings = jsonencode({ "commandToExecute" = "powershell -c $Script = Invoke-WebRequest '${var.vm_extension_custom_script}' -usebasicparsing; $ScriptBlock = [Scriptblock]::Create($Script.Content); Invoke-Command -ScriptBlock $ScriptBlock" })
+  
+  settings = <<SETTINGS
+  { "commandToExecute" = "powershell -c [System.Environment]::SetEnvironmentVariable('Hangfire_BackgroundJobServerOptions_WorkerCount','10',[System.EnvironmentVariableTarget]::Machine)" }
+  SETTINGS
   }
+  
 
   network_interface {
     name    = "vmss-${var.project}-nic"

--- a/azure/windows-scaleset/main.tf
+++ b/azure/windows-scaleset/main.tf
@@ -51,10 +51,8 @@ resource "azurerm_windows_virtual_machine_scale_set" "scaleset" {
   { "commandToExecute": "powershell -c [System.Environment]::SetEnvironmentVariable('Hangfire_BackgroundJobServerOptions_WorkerCount','${var.max_number_threads}',[System.EnvironmentVariableTarget]::Machine);[System.Environment]::SetEnvironmentVariable('Hangfire_BackgroundJobServerOptions_Queues','${var.queue_name}',[System.EnvironmentVariableTarget]::Machine)"     
   }
   SETTINGS
-  }
-  
-
-  network_interface {
+  }  
+    network_interface {
     name    = "vmss-${var.project}-nic"
     primary = true
 

--- a/azure/windows-scaleset/variables.tf
+++ b/azure/windows-scaleset/variables.tf
@@ -23,11 +23,6 @@ variable "vm_count" {
   description = "Number of virtual machines to be created on the scale set."
 }
 
-variable "vm_extension_custom_script" {
-  type        = string
-  description = "URL to the post installation script extension."
-}
-
 variable "vnet_resource_group_name" {
   type        = string
   description = "defines the vnet resource group."

--- a/azure/windows-scaleset/variables.tf
+++ b/azure/windows-scaleset/variables.tf
@@ -44,3 +44,13 @@ variable "subnet_name" {
   type        = string
   description = "defines azure subnet name."
 }
+
+variable "max_number_threads" {
+  type        = number
+  description = "defines the max number of threads that the worker can fire up."
+}
+
+variable "queue_name" {
+  type        = string
+  description = "defines the queue that the worker will be listening for events."
+}


### PR DESCRIPTION
Used inline commands to setup both queue name and number of threads instead of powershell script for the Environment Variables in Worker scaleset. 