### PR TITLE
azure app service site config

### DIFF
--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -36,11 +36,7 @@ resource "azurerm_app_service" "app" {
   resource_group_name = azurerm_resource_group.app.name
   app_service_plan_id = azurerm_app_service_plan.app.id
   https_only = true
-
-  site_config {
-    linux_fx_version = "DOTNETCORE|3.1"
-    ftps_state = Disabled
-  }
+  ftps_state = Disabled
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
Terraform Cloud is throwing the following error

<img width="1171" alt="Screenshot 2021-12-26 at 10 06 29" src="https://user-images.githubusercontent.com/904062/147404984-7c29abe0-ceaa-4255-90eb-4a399d1f1d23.png">

Accordingly, with Terraform documentation, the `ftps` property belongs to the resource root.