### PR TITLE
ftps removed from azure appservice

### DIFF
--- a/azure/appservice/main.tf
+++ b/azure/appservice/main.tf
@@ -36,8 +36,6 @@ resource "azurerm_app_service" "app" {
   resource_group_name = azurerm_resource_group.app.name
   app_service_plan_id = azurerm_app_service_plan.app.id
   https_only = true
-  ftps_state = Disabled
-
   identity {
     type = "SystemAssigned"
   }


### PR DESCRIPTION
# Description

Removed the `ftps_state` property because it's throwing exceptions when applying or planning, despite the fact that it's compliant with docs  the latest version

# Motivation and Context

Without removing the property, we cannot provision app service on azure.

# How Has This Been Tested?

Local cli.

# Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
