### PR TITLE
adding subnets and Vnet integration for the appservice module

### DIFF
--- a/azure/appservice-windows/main.tf
+++ b/azure/appservice-windows/main.tf
@@ -11,11 +11,9 @@ resource "azurerm_app_service_plan" "app" {
   }
 }
 
-resource "azurerm_virtual_network" "app" {
-  name                = "vnet-${var.project}-${var.environment}"
-  location            = local.location
-  resource_group_name = var.resource_group
-  address_space       =  ["172.22.0.0/16"]
+data "azurerm_virtual_network" "vnet" {
+  name                = var.vnet.name
+  resource_group_name = var.vnet.resource_group_name
 }
 resource "azurerm_subnet" "app" {
   name                 = "snet-${var.project}-${var.environment}"

--- a/azure/appservice-windows/main.tf
+++ b/azure/appservice-windows/main.tf
@@ -44,7 +44,6 @@ resource "azurerm_app_service" "app" {
   
   site_config {
     always_on                 = true
-    #virtual_network_name      = "${azurerm_virtual_network.vnet.name}"
     dotnet_framework_version  = var.dotnetVersion
     ftps_state                = "FtpsOnly"
     http2_enabled             = true

--- a/azure/appservice-windows/main.tf
+++ b/azure/appservice-windows/main.tf
@@ -11,6 +11,28 @@ resource "azurerm_app_service_plan" "app" {
   }
 }
 
+resource "azurerm_virtual_network" "app" {
+  name                = "vnet-${var.project}-${var.environment}"
+  location            = local.location
+  resource_group_name = var.resource_group
+  address_space       =  ["172.22.0.0/16"]
+}
+resource "azurerm_subnet" "app" {
+  name                 = "snet-${var.project}-${var.environment}"
+  resource_group_name  = var.resource_group
+  virtual_network_name = azurerm_virtual_network.app.name
+  address_prefixes     = ["172.22.0.0/24"]
+
+  delegation {
+    name = "snet-delegation"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
 resource "azurerm_app_service" "app" {
   name                    = "as-${var.project}-${var.environment}"
   location                = local.location
@@ -24,6 +46,7 @@ resource "azurerm_app_service" "app" {
   
   site_config {
     always_on                 = true
+    #virtual_network_name      = "${azurerm_virtual_network.vnet.name}"
     dotnet_framework_version  = var.dotnetVersion
     ftps_state                = "FtpsOnly"
     http2_enabled             = true
@@ -48,4 +71,9 @@ resource "azurerm_application_insights" "app" {
   workspace_id        = azurerm_log_analytics_workspace.app.id
   application_type    = "web"
 
+}
+
+resource "azurerm_app_service_virtual_network_swift_connection" "app" {
+  app_service_id = azurerm_app_service.app.id
+  subnet_id      = azurerm_subnet.app.id
 }

--- a/azure/appservice-windows/main.tf
+++ b/azure/appservice-windows/main.tf
@@ -9,26 +9,8 @@ resource "azurerm_app_service_plan" "app" {
     tier = var.plan
     size = var.size
   }
-}
 
-data "azurerm_virtual_network" "vnet" {
-  name                = var.vnet.name
-  resource_group_name = var.vnet.resource_group_name
-}
-resource "azurerm_subnet" "app" {
-  name                 = "snet-${var.project}-${var.environment}"
-  resource_group_name  = var.resource_group
-  virtual_network_name = azurerm_virtual_network.app.name
-  address_prefixes     = ["172.22.0.0/24"]
-
-  delegation {
-    name = "snet-delegation"
-
-    service_delegation {
-      name    = "Microsoft.Web/serverFarms"
-      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-    }
-  }
+  tags     = var.tags
 }
 
 resource "azurerm_app_service" "app" {
@@ -52,6 +34,8 @@ resource "azurerm_app_service" "app" {
     websockets_enabled        = false
     remote_debugging_enabled  = false
   }
+
+  tags     = var.tags
 }
 
 resource "azurerm_log_analytics_workspace" "app" {
@@ -59,6 +43,8 @@ resource "azurerm_log_analytics_workspace" "app" {
   location            = local.location
   resource_group_name = var.resource_group  
   retention_in_days   = 90
+
+  tags     = var.tags
 }
 
 resource "azurerm_application_insights" "app" {  
@@ -68,9 +54,11 @@ resource "azurerm_application_insights" "app" {
   workspace_id        = azurerm_log_analytics_workspace.app.id
   application_type    = "web"
 
+  tags     = var.tags
+
 }
 
 resource "azurerm_app_service_virtual_network_swift_connection" "app" {
   app_service_id = azurerm_app_service.app.id
-  subnet_id      = azurerm_subnet.app.id
+  subnet_id      = var.vnet_subnet_id
 }

--- a/azure/appservice-windows/terraform.tf
+++ b/azure/appservice-windows/terraform.tf
@@ -1,10 +1,4 @@
 terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.93.1"
-    }
-  }
 
   required_version = ">= 1.0.0"
 }

--- a/azure/appservice-windows/variables.tf
+++ b/azure/appservice-windows/variables.tf
@@ -8,17 +8,17 @@ variable "project" {
 }
 variable "plan" {
   description = "defines the app service plan type (i.e: Standard, Premium)."
-  type = string
+  type        = string
 }
 variable "size" {
   description = "defines the app service size type (i.e: S1, P1V2 etc)."
-  type = string
+  type        = string
 }
 variable "dotnetVersion" {
   description = "defines the dotnet framework version for app service (i.e: 4.6, 4.7, 4.8)."
-  type = string
+  type        = string
 }
 variable "resource_group" {
   description = "azure resource group name."
-  type = string
+  type        = string
 }

--- a/azure/appservice-windows/variables.tf
+++ b/azure/appservice-windows/variables.tf
@@ -2,23 +2,37 @@ variable "environment" {
   description = "defines the environment to provision the resources."
   type        = string
 }
+
 variable "project" {
   description = "project name. It will be used by some resources."
   type        = string
 }
+
 variable "plan" {
   description = "defines the app service plan type (i.e: Standard, Premium)."
   type        = string
 }
+
 variable "size" {
   description = "defines the app service size type (i.e: S1, P1V2 etc)."
   type        = string
 }
+
 variable "dotnetVersion" {
   description = "defines the dotnet framework version for app service (i.e: 4.6, 4.7, 4.8)."
   type        = string
 }
+
 variable "resource_group" {
   description = "azure resource group name."
   type        = string
+}
+
+variable "vnet" {
+  description = "azure nmbrs vnet information struct that holds vnet required information."
+  type = map(string)
+  default = {
+    name: "default"
+    resource_group_name: "default"
+  }
 }

--- a/azure/appservice-windows/variables.tf
+++ b/azure/appservice-windows/variables.tf
@@ -19,7 +19,7 @@ variable "size" {
 }
 
 variable "dotnetVersion" {
-  description = "defines the dotnet framework version for app service (i.e: 4.6, 4.7, 4.8)."
+  description = "defines the dotnet framework version for app service (i.e: v2.0 v4.0 v5.0 v6.0)."
   type        = string
 }
 
@@ -28,11 +28,12 @@ variable "resource_group" {
   type        = string
 }
 
-variable "vnet" {
-  description = "azure nmbrs vnet information struct that holds vnet required information."
+variable "vnet_subnet_id" {
+  type = string
+  description = "azure vnet subnet id that is going to be associated with the app service."
+}
+
+variable "tags" {
+  description = "nmbrs list of mandatory resource tags."
   type = map(string)
-  default = {
-    name: "default"
-    resource_group_name: "default"
-  }
 }

--- a/azure/resource-group/main.tf
+++ b/azure/resource-group/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "rg" {
-  name     = "rg-${var.project}-${var.tags["environment"]}"
+  name     = "rg-${var.project}-${var.environment}"
   location = local.location
   tags     = var.tags
 }

--- a/azure/resource-group/variables.tf
+++ b/azure/resource-group/variables.tf
@@ -7,3 +7,8 @@ variable "tags" {
   description = "nmbrs list of mandatory resource tags."
   type = map(string)
 }
+
+variable "environment" {
+  description = "nmbrs environment name."
+  type = string
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Adding Subnet and VNet Resources to app service module and enabling the VNet Integration in the template
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
I have kept the address space and the address prefix hardcoded for now since i got issue when trying to add it as a variable, was not able to fix it so keeping this for now till i find the solution. 
Please add your comments for any changes needed or something i might have forgotten i will update them.

Ran Locally and tested out. Below is the terraform Plan for the change. 

```

  # module.appservice.azurerm_app_service.app will be created
  + resource "azurerm_app_service" "app" {
      + app_service_plan_id               = (known after apply)
      + app_settings                      = (known after apply)
      + client_affinity_enabled           = false
      + client_cert_enabled               = false
      + client_cert_mode                  = (known after apply)
      + custom_domain_verification_id     = (known after apply)
      + default_site_hostname             = (known after apply)
      + enabled                           = true
      + https_only                        = true
      + id                                = (known after apply)
      + key_vault_reference_identity_id   = (known after apply)
      + location                          = "westeurope"
      + name                              = "as-payroll-test"
      + outbound_ip_address_list          = (known after apply)
      + outbound_ip_addresses             = (known after apply)
      + possible_outbound_ip_address_list = (known after apply)
      + possible_outbound_ip_addresses    = (known after apply)
      + resource_group_name               = "rg-payroll-test"
      + site_credential                   = (known after apply)

      + auth_settings {
          + additional_login_params        = (known after apply)
          + allowed_external_redirect_urls = (known after apply)
          + default_provider               = (known after apply)
          + enabled                        = (known after apply)
          + issuer                         = (known after apply)
          + runtime_version                = (known after apply)
          + token_refresh_extension_hours  = (known after apply)
          + token_store_enabled            = (known after apply)
          + unauthenticated_client_action  = (known after apply)

          + active_directory {
              + allowed_audiences = (known after apply)
              + client_id         = (known after apply)
              + client_secret     = (sensitive value)
            }

          + facebook {
              + app_id       = (known after apply)
              + app_secret   = (sensitive value)
              + oauth_scopes = (known after apply)
            }

          + google {
              + client_id     = (known after apply)
              + client_secret = (sensitive value)
              + oauth_scopes  = (known after apply)
            }

          + microsoft {
              + client_id     = (known after apply)
              + client_secret = (sensitive value)
              + oauth_scopes  = (known after apply)
            }

          + twitter {
              + consumer_key    = (known after apply)
              + consumer_secret = (sensitive value)
            }
        }

      + connection_string {
          + name  = (known after apply)
          + type  = (known after apply)
          + value = (sensitive value)
        }

      + identity {
          + principal_id = (known after apply)
          + tenant_id    = (known after apply)
          + type         = "SystemAssigned"
        }

      + logs {
          + detailed_error_messages_enabled = (known after apply)
          + failed_request_tracing_enabled  = (known after apply)

          + application_logs {
              + file_system_level = (known after apply)

              + azure_blob_storage {
                  + level             = (known after apply)
                  + retention_in_days = (known after apply)
                  + sas_url           = (sensitive value)
                }
            }

          + http_logs {
              + azure_blob_storage {
                  + retention_in_days = (known after apply)
                  + sas_url           = (sensitive value)
                }

              + file_system {
                  + retention_in_days = (known after apply)
                  + retention_in_mb   = (known after apply)
                }
            }
        }

      + site_config {
          + acr_use_managed_identity_credentials = false
          + always_on                            = true
          + dotnet_framework_version             = "v4.0"
          + ftps_state                           = "FtpsOnly"
          + http2_enabled                        = true
          + ip_restriction                       = (known after apply)
          + linux_fx_version                     = (known after apply)
          + local_mysql_enabled                  = (known after apply)
          + managed_pipeline_mode                = "Integrated"
          + min_tls_version                      = (known after apply)
          + number_of_workers                    = (known after apply)
          + remote_debugging_enabled             = false
          + remote_debugging_version             = (known after apply)
          + scm_ip_restriction                   = (known after apply)
          + scm_type                             = (known after apply)
          + scm_use_main_ip_restriction          = false
          + use_32_bit_worker_process            = false
          + vnet_route_all_enabled               = (known after apply)
          + websockets_enabled                   = false
          + windows_fx_version                   = (known after apply)

          + cors {
              + allowed_origins     = (known after apply)
              + support_credentials = (known after apply)
            }
        }

      + source_control {
          + branch             = (known after apply)
          + manual_integration = (known after apply)
          + repo_url           = (known after apply)
          + rollback_enabled   = (known after apply)
          + use_mercurial      = (known after apply)
        }

      + storage_account {
          + access_key   = (sensitive value)
          + account_name = (known after apply)
          + mount_path   = (known after apply)
          + name         = (known after apply)
          + share_name   = (known after apply)
          + type         = (known after apply)
        }
    }

  # module.appservice.azurerm_app_service_plan.app will be created
  + resource "azurerm_app_service_plan" "app" {
      + id                           = (known after apply)
      + kind                         = "Windows"
      + location                     = "westeurope"
      + maximum_elastic_worker_count = (known after apply)
      + maximum_number_of_workers    = (known after apply)
      + name                         = "asp-payroll-test"
      + reserved                     = false
      + resource_group_name          = "rg-payroll-test"

      + sku {
          + capacity = (known after apply)
          + size     = "P1V2"
          + tier     = "PremiumV2"
        }
    }

  # module.appservice.azurerm_app_service_virtual_network_swift_connection.app will be created
  + resource "azurerm_app_service_virtual_network_swift_connection" "app" {
      + app_service_id = (known after apply)
      + id             = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.appservice.azurerm_application_insights.app will be created
  + resource "azurerm_application_insights" "app" {
      + app_id                                = (known after apply)
      + application_type                      = "web"
      + connection_string                     = (sensitive value)
      + daily_data_cap_in_gb                  = (known after apply)
      + daily_data_cap_notifications_disabled = (known after apply)
      + disable_ip_masking                    = false
      + id                                    = (known after apply)
      + instrumentation_key                   = (sensitive value)
      + internet_ingestion_enabled            = true
      + internet_query_enabled                = true
      + local_authentication_disabled         = false
      + location                              = "westeurope"
      + name                                  = "appins-payroll-test"
      + resource_group_name                   = "rg-payroll-test"
      + retention_in_days                     = 90
      + sampling_percentage                   = 100
      + workspace_id                          = (known after apply)
    }

  # module.appservice.azurerm_log_analytics_workspace.app will be created
  + resource "azurerm_log_analytics_workspace" "app" {
      + daily_quota_gb                     = -1
      + id                                 = (known after apply)
      + internet_ingestion_enabled         = true
      + internet_query_enabled             = true
      + location                           = "westeurope"
      + name                               = "wsp-payroll-test"
      + portal_url                         = (known after apply)
      + primary_shared_key                 = (sensitive value)
      + reservation_capacity_in_gb_per_day = (known after apply)
      + reservation_capcity_in_gb_per_day  = (known after apply)
      + resource_group_name                = "rg-payroll-test"
      + retention_in_days                  = 90
      + secondary_shared_key               = (sensitive value)
      + sku                                = "PerGB2018"
      + workspace_id                       = (known after apply)
    }

  # module.appservice.azurerm_subnet.app will be created
  + resource "azurerm_subnet" "app" {
      + address_prefix                                 = (known after apply)
      + address_prefixes                               = [
          + "172.22.0.0/24",
        ]
      + enforce_private_link_endpoint_network_policies = false
      + enforce_private_link_service_network_policies  = false
      + id                                             = (known after apply)
      + name                                           = "snet-payroll-test"
      + resource_group_name                            = "rg-payroll-test"
      + virtual_network_name                           = "vnet-payroll-test"

      + delegation {
          + name = "snet-delegation"

          + service_delegation {
              + actions = [
                  + "Microsoft.Network/virtualNetworks/subnets/action",
                ]
              + name    = "Microsoft.Web/serverFarms"
            }
        }
    }

  # module.appservice.azurerm_virtual_network.app will be created
  + resource "azurerm_virtual_network" "app" {
      + address_space         = [
          + "172.22.0.0/16",
        ]
      + dns_servers           = (known after apply)
      + guid                  = (known after apply)
      + id                    = (known after apply)
      + location              = "westeurope"
      + name                  = "vnet-payroll-test"
      + resource_group_name   = "rg-payroll-test"
      + subnet                = (known after apply)
      + vm_protection_enabled = false
    }

  # module.resource_group.azurerm_resource_group.rg will be created
  + resource "azurerm_resource_group" "rg" {
      + id       = (known after apply)
      + location = "westeurope"
      + name     = "rg-payroll-test"
      + tags     = {
          + "country"     = "nl"
          + "environment" = "test"
          + "product"     = "internal"
          + "squad"       = "shared"
        }
    }

Plan: 8 to add, 0 to change, 0 to destroy.
```
# Screenshots

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
