### PR TITLE
feature(github-team): remove deprecated parameter create_default_maintainer

### DIFF
--- a/github/team/main.tf
+++ b/github/team/main.tf
@@ -1,9 +1,8 @@
 # Add a team to the organization
 resource "github_team" "team" {
-  name                      = var.name
-  description               = var.description
-  create_default_maintainer = false
-  privacy                   = "closed"
-  parent_team_id            = var.parent_team != "" && var.parent_team != null ? data.github_team.parent_team[0].id : null
+  name           = var.name
+  description    = var.description
+  privacy        = "closed"
+  parent_team_id = var.parent_team != "" && var.parent_team != null ? data.github_team.parent_team[0].id : null
 
 }


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to remove the parameter `create_default_maintainer` deprecated by the `integrations/github` provider
## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->
- No behavioral changes
- 
### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
