### PR TITLE
fix(ssl_certificate): ignore validity_in_years to prevent drift

### DIFF
--- a/azure/ssl_certificate/README.md
+++ b/azure/ssl_certificate/README.md
@@ -5,6 +5,27 @@
 
 The `ssl_certificate` module provisions an SSL certificate in Azure for a specified domain name and resource group. It is designed to be stored in key vaults so it can be used by any application type.
 
+## Certificate validity
+
+The module does **not** expose or set `validity_in_years` on the underlying `azurerm_app_service_certificate_order`, and it explicitly ignores that attribute in the resource lifecycle. This is intentional, for the reasons below.
+
+1. **The Azure ARM contract only accepts `1`.** The official ARM reference for `Microsoft.CertificateRegistration/certificateOrders` documents `validityInYears` as *"Duration in years (must be 1)"* ([ARM reference](https://learn.microsoft.com/en-us/azure/templates/microsoft.certificateregistration/certificateorders)). The Terraform `azurerm` provider advertises a range of 1–3, but Azure rejects anything other than 1 in practice.
+
+2. **The actual certificate lifetime is set by the CA, not by this field.** App Service Certificates are issued by GoDaddy and are bound by the [CA/Browser Forum Baseline Requirements](https://cabforum.org/working-groups/server/baseline-requirements/documents/). Ballot **[SC-081v3](https://cabforum.org/2025/04/11/ballot-sc-081v3-introduce-schedule-of-reducing-validity-and-data-reuse-periods/)** (adopted April 2025) imposes the following maximum TLS certificate lifetimes:
+
+   | Effective date | Max validity |
+   |---|---|
+   | until 2026-03-15 | 398 days |
+   | 2026-03-15 → 2027-03-15 | **200 days** |
+   | 2027-03-15 → 2029-03-15 | 100 days |
+   | from 2029-03-15 | 47 days |
+
+   Newly issued certificates therefore have lifetimes shorter than one year regardless of what is requested in Terraform. Auto-renew (`auto_renew = true`) keeps the certificate continuously valid by re-issuing within the renewal window.
+
+3. **Setting the field produces perpetual drift.** Once the certificate order is issued, the ARM API returns `validityInYears = 0` on subsequent reads. With the field set in Terraform, every plan reports a change from the configured value back to `0`. Ignoring the attribute in `lifecycle.ignore_changes` is the supported way to suppress this drift.
+
+Because the field is optional in the provider, has a sensible default (`1`, the only legal ARM value), is overridden by the CA, and causes drift if set, it is omitted from the module surface and ignored at the lifecycle level.
+
 ## Requirements
 
 | Name | Version |

--- a/azure/ssl_certificate/main.tf
+++ b/azure/ssl_certificate/main.tf
@@ -5,8 +5,10 @@ resource "azurerm_app_service_certificate_order" "certificate" {
   distinguished_name  = "CN=*.${var.domain_name}"
   product_type        = "WildCard"
   auto_renew          = true
-  validity_in_years   = 1
   lifecycle {
-    ignore_changes = [tags]
+    # validity_in_years is set by the issuing CA (CAB Forum SC-081v3 caps lifetimes;
+    # 200 days from 2026-03-15, 100 from 2027-03-15, 47 from 2029-03-15) and the ARM
+    # API reads it back as 0 after issuance, so any value here causes perpetual drift.
+    ignore_changes = [tags, validity_in_years]
   }
 }


### PR DESCRIPTION
## Context

  The ssl_certificate module sets validity_in_years = 1 on azurerm_app_service_certificate_order. Every plan reports drift on this field, and certificates in the portal are issued for ~200 days instead of the expected year.

## Root cause

  Two unrelated factors meet here:

  1. ARM read-back returns 0. The official ARM reference for Microsoft.CertificateRegistration/certificateOrders documents `validityInYears` as "Duration in years (must be 1)". After the order is issued, the API reads the field back as 0, so Terraform sees a perpetual diff (1 in config vs 0 in state) regardless of what is configured.
  2. Real lifetime is governed by the CA, not the field. App Service Certificates are issued by GoDaddy, bound by the CA/Browser Forum Baseline Requirements. Ballot SC-081v3 (https://cabforum.org/2025/04/11/ballot-sc-081v3-introduce-schedule-of-reducing-validity-and-data-reuse-periods/)
(adopted April 2025) caps max TLS certificate lifetimes:

  | Effective               | Max validity           |
  |-------------------------|------------------------|
  | until 2026-03-15        | 398 days               |
  | 2026-03-15 → 2027-03-15 | 200 days ← we are here |
  | 2027-03-15 → 2029-03-15 | 100 days               |
  | from 2029-03-15         | 47 days                |

  2. A test cert issued 2026-05-07 has notAfter = 2026-11-21 (~198 days), consistent with the current 200-day cap. validity_in_years has no effect on this.

  Changes

  - azure/ssl_certificate/main.tf: removed validity_in_years = 1; added
  validity_in_years to lifecycle.ignore_changes alongside the existing tags.
  - azure/ssl_certificate/README.md: added a "Certificate validity" section
  documenting the ARM constraint, the SC-081v3 reduction schedule, and the
  rationale for ignoring the field.

  Impact

  - Public module surface unchanged. No variables added, removed, or renamed.
   Existing callers don't need to update anything.
  - Eliminates perpetual plan drift on every consumer of this module.
  - No functional change to the issued certificate. Validity was already
  determined by the CA — this PR just stops pretending Terraform controls it.

  References

  - ARM reference: Microsoft.CertificateRegistration/certificateOrders (https://learn.microsoft.com/en-us/azure/templates/microsoft.certificateregistration/certificateorders)
  - Azure docs: Manage App Service Certificates (https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate)
  - CAB Forum ballot SC-081v3 (https://cabforum.org/2025/04/11/ballot-sc-081v3-introduce-schedule-of-reducing-validity-and-data-reuse-periods/)