### PR TITLE
feature(private_endpoint): accept subnet_id directly and drop subnet data lookup

### DIFF
--- a/azure/private_endpoint/README.md
+++ b/azure/private_endpoint/README.md
@@ -1,15 +1,23 @@
+# Private Endpoint Module
+
+## Summary
+
+The `private_endpoint` module is a Terraform abstraction that implements the Terraform code needed to provision a single Azure Private Endpoint connecting a target resource to a private DNS zone, allowing private traffic to reach the service.
+
+The module is policy-neutral — it accepts the target resource's ID and the subnet ID directly, without doing any internal data-source lookups. Callers wrap the module once per (target resource, subresource) pair.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, < 2.0.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.117 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.117.1 |
 
 ## Modules
@@ -19,49 +27,44 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_private_endpoint.endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
-| [azurerm_subnet.subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_location"></a> [location](#input\_location) | The location where the resources will be deployed in Azure. For an exaustive list of locations, please use the command 'az account list-locations -o table'. | `string` | n/a | yes |
-| <a name="input_network_settings"></a> [network\_settings](#input\_network\_settings) | Defines the network settings for the resources, specifying the subnet, virtual network name, and the resource group for the virtual network. | <pre>object(<br/>    {<br/>      subnet_name              = string<br/>      vnet_name                = string<br/>      vnet_resource_group_name = string<br/>    }<br/>  )</pre> | n/a | yes |
 | <a name="input_private_dns_zone_id"></a> [private\_dns\_zone\_id](#input\_private\_dns\_zone\_id) | Defines the private dns zone resource ID. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of an existing Resource Group. | `string` | n/a | yes |
 | <a name="input_resource_settings"></a> [resource\_settings](#input\_resource\_settings) | Defines the settings for the resource the private endpoint will connect to.<br/><br/>- `name`: the workload identifier, used to compose the PEP name (`pep-<name>-<subresource_name>`).<br/>- `resource_id`: the full Azure resource ID of the target (e.g. the `.id` output of the resource's module).<br/>- `subresource_name`: the Azure private-link subresource (e.g. `blob`, `vault`, `sites`, `SQL`). For the full list of valid values per resource type, see:<br/>  https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview#private-link-resource | <pre>object(<br/>    {<br/>      name             = string<br/>      resource_id      = string<br/>      subresource_name = string<br/>    }<br/>  )</pre> | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The full Azure resource ID of the subnet where the private endpoint NIC will be created. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_id"></a> [id](#output\_id) | The private endpoint ID. |
 | <a name="output_name"></a> [name](#output\_name) | The private endpoint name. |
 | <a name="output_network_interface_id"></a> [network\_interface\_id](#output\_network\_interface\_id) | The ID of the network interface associated with the private endpoint. |
 | <a name="output_private_ip_address"></a> [private\_ip\_address](#output\_private\_ip\_address) | The private IP address associated with the private endpoint. |
+<!-- END_TF_DOCS -->
 
 ## How to use it?
-
-A number of code snippets demonstrating different use cases for the module have been included to help you understand how to use the module in Terraform.
 
 ```hcl
 module "private_endpoint" {
   source              = "git::github.com/Nmbrs/tf-modules//azure/private_endpoint"
   resource_group_name = "rg-myrg"
   location            = "westeurope"
+
   resource_settings = {
     name             = "as-web-test"
     resource_id      = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-resource-rg/providers/Microsoft.Web/sites/as-web-test"
     subresource_name = "sites"
   }
-  network_settings = {
-    vnet_name                = "vnet-mynetwork"
-    subnet_name              = "snet-mysnet-002"
-    vnet_resource_group_name = "rg-networks"
-  }
+
+  subnet_id           = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-networks/providers/Microsoft.Network/virtualNetworks/vnet-mynetwork/subnets/snet-mysnet-002"
   private_dns_zone_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/my-rg/providers/Microsoft.Network/privateDnsZones/privatelink.azurewebsites.net"
 }
 ```
-<!-- END_TF_DOCS -->

--- a/azure/private_endpoint/data.tf
+++ b/azure/private_endpoint/data.tf
@@ -1,5 +1,0 @@
-data "azurerm_subnet" "subnet" {
-  name                 = var.network_settings.subnet_name
-  virtual_network_name = var.network_settings.vnet_name
-  resource_group_name  = var.network_settings.vnet_resource_group_name
-}

--- a/azure/private_endpoint/main.tf
+++ b/azure/private_endpoint/main.tf
@@ -2,7 +2,7 @@ resource "azurerm_private_endpoint" "endpoint" {
   name                          = local.private_endpoint_name
   location                      = var.location
   resource_group_name           = var.resource_group_name
-  subnet_id                     = data.azurerm_subnet.subnet.id
+  subnet_id                     = var.subnet_id
   custom_network_interface_name = "nic-${local.private_endpoint_name}"
 
   private_service_connection {

--- a/azure/private_endpoint/variables.tf
+++ b/azure/private_endpoint/variables.tf
@@ -8,15 +8,9 @@ variable "location" {
   type        = string
 }
 
-variable "network_settings" {
-  description = "Defines the network settings for the resources, specifying the subnet, virtual network name, and the resource group for the virtual network."
-  type = object(
-    {
-      subnet_name              = string
-      vnet_name                = string
-      vnet_resource_group_name = string
-    }
-  )
+variable "subnet_id" {
+  description = "The full Azure resource ID of the subnet where the private endpoint NIC will be created."
+  type        = string
 }
 
 variable "resource_settings" {


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to replace the network_settings = { subnet_name, vnet_name, vnet_resource_group_name } triple input with a single subnet_id string, letting callers pass the subnet's Azure resource ID directly. This drops the module's internal azurerm_subnet data lookup, removes the implicit Reader-on-the-VNet permission, and aligns the subnet input with the same "pass IDs" pattern already used for the target resource (resource_settings.resource_id).
## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [ ] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
