### PR TITLE
feature(redis_cache): align with data-tier patterns (PEP + optional sequence_number)

### DIFF
--- a/azure/redis_cache/README.md
+++ b/azure/redis_cache/README.md
@@ -42,7 +42,7 @@ The Azure Redis Cache module is a Terraform module that provides an easy and con
 | <a name="input_private_endpoint_settings"></a> [private\_endpoint\_settings](#input\_private\_endpoint\_settings) | Settings for the private endpoint provisioned by this module. `subnet_id` is the resource ID of the subnet where the PEP NIC lands. `private_dns_zone_ids` maps each required subresource to its private DNS zone resource ID. | <pre>object({<br/>    subnet_id = string<br/>    private_dns_zone_ids = object({<br/>      redisCache = string<br/>    })<br/>  })</pre> | n/a | yes |
 | <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | Whether or not public network access is allowed for this Redis instance. | `bool` | `false` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Specifies the name of the resource group where the resource should be provisioned. | `string` | n/a | yes |
-| <a name="input_sequence_number"></a> [sequence\_number](#input\_sequence\_number) | A numeric value used to ensure uniqueness for resource names. | `number` | n/a | yes |
+| <a name="input_sequence_number"></a> [sequence\_number](#input\_sequence\_number) | Optional numeric instance counter, zero-padded as `-NNN` suffix. Use only when provisioning multiple Redis caches for the same workload/env/region (e.g., sharding). Omit for the common single-instance case. | `number` | `null` | no |
 | <a name="input_shard_count"></a> [shard\_count](#input\_shard\_count) | The number of shards for the Redis cluster. Only required when using a Premium SKU. | `number` | `0` | no |
 | <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | Configuration of the size and capacity of the Redis cache. | `string` | n/a | yes |
 | <a name="input_workload"></a> [workload](#input\_workload) | Short, descriptive name for the application, service, or workload. Used in resource naming conventions. | `string` | n/a | yes |
@@ -67,6 +67,8 @@ The Azure Redis Cache module is a Terraform module that provides an easy and con
 
 The module always provisions a private endpoint for the Redis cache (`redisCache` subresource). Every caller must supply `private_endpoint_settings` with the subnet ID where the PEP NIC lands and the resource ID of the `privatelink.redis.cache.windows.net` DNS zone. `public_network_access_enabled` defaults to `false` (PEP-only posture); set it to `true` only when public reachability is genuinely needed alongside the private endpoint.
 
+`sequence_number` is optional and intended only for power-user scenarios where multiple Redis caches share the same workload/env/region (e.g., sharding). Omit it for the common single-instance case. When supplied, it is appended to the resource name as a zero-padded `-NNN` suffix.
+
 ### Basic Redis Cache (Minimal Configuration)
 
 This example shows the minimum required configuration for a Basic Redis cache.
@@ -77,7 +79,6 @@ module "redis_cache" {
 
   workload            = "shared"
   company_prefix      = "nmbrs"
-  sequence_number     = 1
   environment         = "dev"
   location            = "westeurope"
   resource_group_name = "rg-yha-dev"
@@ -104,7 +105,6 @@ module "redis_cache" {
 
   workload            = "auth"
   company_prefix      = "nmbrs"
-  sequence_number     = 2
   environment         = "prod"
   location            = "westeurope"
   resource_group_name = "rg-module-prod"
@@ -131,7 +131,6 @@ module "redis_cache" {
 
   workload            = "session"
   company_prefix      = "nmbrs"
-  sequence_number     = 1
   environment         = "prod"
   location            = "westeurope"
   resource_group_name = "rg-try-prod"
@@ -159,7 +158,6 @@ module "redis_cache" {
 
   workload            = "analytics"
   company_prefix      = "nmbrs"
-  sequence_number     = 1
   environment         = "prod"
   location            = "westeurope"
   resource_group_name = "rg-logs-prod"

--- a/azure/redis_cache/README.md
+++ b/azure/redis_cache/README.md
@@ -1,42 +1,45 @@
-<!-- BEGIN_TF_DOCS -->
 # Redis Cache Module
 
 ## Summary
 
-The Azure Redis Cache module is a Terraform module that provides an easy and consistent way to create and manage Redis cache instances in Azure. This module enforces organization-specific naming conventions and security policies while simplifying the provisioning process.
+The Azure Redis Cache module is a Terraform module that provides an easy and consistent way to create and manage Redis cache instances in Azure. This module enforces organization-specific naming conventions and security policies while simplifying the provisioning process. A private endpoint is always provisioned (subresource `redisCache`); callers supply the subnet and DNS zone via `private_endpoint_settings`.
 
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, < 2.0.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.117 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.117.1 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_private_endpoint"></a> [private\_endpoint](#module\_private\_endpoint) | git::github.com/Nmbrs/tf-modules//azure/private_endpoint | f41a116c9f31892191b5e3f146a1e361bfc57322 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
-| [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache) | resource |
+| ---- | ---- |
+| [azurerm_redis_cache.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cache_size_in_gb"></a> [cache\_size\_in\_gb](#input\_cache\_size\_in\_gb) | The size of the Redis cache per instance in gigabytes (GB). | `number` | n/a | yes |
 | <a name="input_company_prefix"></a> [company\_prefix](#input\_company\_prefix) | Short, unique prefix for the company / organization. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment in which the resource should be provisioned. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Specifies Azure location where the resources should be provisioned. For an exhaustive list of locations, please use the command 'az account list-locations -o table'. | `string` | n/a | yes |
 | <a name="input_override_name"></a> [override\_name](#input\_override\_name) | Optional override for naming logic. | `string` | `null` | no |
+| <a name="input_private_endpoint_settings"></a> [private\_endpoint\_settings](#input\_private\_endpoint\_settings) | Settings for the private endpoint provisioned by this module. `subnet_id` is the resource ID of the subnet where the PEP NIC lands. `private_dns_zone_ids` maps each required subresource to its private DNS zone resource ID. | <pre>object({<br/>    subnet_id = string<br/>    private_dns_zone_ids = object({<br/>      redisCache = string<br/>    })<br/>  })</pre> | n/a | yes |
 | <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | Whether or not public network access is allowed for this Redis instance. | `bool` | `false` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Specifies the name of the resource group where the resource should be provisioned. | `string` | n/a | yes |
 | <a name="input_sequence_number"></a> [sequence\_number](#input\_sequence\_number) | A numeric value used to ensure uniqueness for resource names. | `number` | n/a | yes |
@@ -47,7 +50,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_hostname"></a> [hostname](#output\_hostname) | The Hostname of the Redis Instance. |
 | <a name="output_id"></a> [id](#output\_id) | The Redis ID. |
 | <a name="output_name"></a> [name](#output\_name) | The name of the Redis Instance. |
@@ -58,10 +61,11 @@ No modules.
 | <a name="output_secondary_connection_string"></a> [secondary\_connection\_string](#output\_secondary\_connection\_string) | The secondary connection string of the Redis Instance. |
 | <a name="output_ssl_port"></a> [ssl\_port](#output\_ssl\_port) | The SSL Port of the Redis Instance. |
 | <a name="output_workload"></a> [workload](#output\_workload) | The redis instance workload name. |
+<!-- END_TF_DOCS -->
 
 ## How to use it?
 
-A number of code snippets demonstrating different use cases for the module have been included to help you understand how to use the module in Terraform.
+The module always provisions a private endpoint for the Redis cache (`redisCache` subresource). Every caller must supply `private_endpoint_settings` with the subnet ID where the PEP NIC lands and the resource ID of the `privatelink.redis.cache.windows.net` DNS zone. `public_network_access_enabled` defaults to `false` (PEP-only posture); set it to `true` only when public reachability is genuinely needed alongside the private endpoint.
 
 ### Basic Redis Cache (Minimal Configuration)
 
@@ -72,7 +76,7 @@ module "redis_cache" {
   source = "git::github.com/Nmbrs/tf-modules//azure/redis_cache"
 
   workload            = "shared"
-  company_prefix      = "org"
+  company_prefix      = "nmbrs"
   sequence_number     = 1
   environment         = "dev"
   location            = "westeurope"
@@ -80,6 +84,13 @@ module "redis_cache" {
 
   sku_name         = "Basic"
   cache_size_in_gb = 1
+
+  private_endpoint_settings = {
+    subnet_id = "/subscriptions/.../subnets/snet-private-endpoints"
+    private_dns_zone_ids = {
+      redisCache = module.dns_zone_redis.id
+    }
+  }
 }
 ```
 
@@ -92,7 +103,7 @@ module "redis_cache" {
   source = "git::github.com/Nmbrs/tf-modules//azure/redis_cache"
 
   workload            = "auth"
-  company_prefix      = "org"
+  company_prefix      = "nmbrs"
   sequence_number     = 2
   environment         = "prod"
   location            = "westeurope"
@@ -101,7 +112,12 @@ module "redis_cache" {
   sku_name         = "Standard"
   cache_size_in_gb = 2.5
 
-  public_network_access_enabled = false
+  private_endpoint_settings = {
+    subnet_id = "/subscriptions/.../subnets/snet-private-endpoints"
+    private_dns_zone_ids = {
+      redisCache = module.dns_zone_redis.id
+    }
+  }
 }
 ```
 
@@ -114,15 +130,22 @@ module "redis_cache" {
   source = "git::github.com/Nmbrs/tf-modules//azure/redis_cache"
 
   workload            = "session"
+  company_prefix      = "nmbrs"
+  sequence_number     = 1
   environment         = "prod"
   location            = "westeurope"
   resource_group_name = "rg-try-prod"
 
   sku_name         = "Premium"
   cache_size_in_gb = 6
-  shard_count      = 0  # No clustering
+  shard_count      = 0 # No clustering
 
-  public_network_access_enabled = false
+  private_endpoint_settings = {
+    subnet_id = "/subscriptions/.../subnets/snet-private-endpoints"
+    private_dns_zone_ids = {
+      redisCache = module.dns_zone_redis.id
+    }
+  }
 }
 ```
 
@@ -135,15 +158,22 @@ module "redis_cache" {
   source = "git::github.com/Nmbrs/tf-modules//azure/redis_cache"
 
   workload            = "analytics"
+  company_prefix      = "nmbrs"
+  sequence_number     = 1
   environment         = "prod"
   location            = "westeurope"
   resource_group_name = "rg-logs-prod"
 
   sku_name         = "Premium"
   cache_size_in_gb = 26
-  shard_count      = 3  # Enable clustering with 3 shards
+  shard_count      = 3 # Enable clustering with 3 shards
 
-  public_network_access_enabled = false
+  private_endpoint_settings = {
+    subnet_id = "/subscriptions/.../subnets/snet-private-endpoints"
+    private_dns_zone_ids = {
+      redisCache = module.dns_zone_redis.id
+    }
+  }
 }
 ```
 
@@ -162,6 +192,12 @@ module "redis_cache" {
 
   sku_name         = "Standard"
   cache_size_in_gb = 6
+
+  private_endpoint_settings = {
+    subnet_id = "/subscriptions/.../subnets/snet-private-endpoints"
+    private_dns_zone_ids = {
+      redisCache = module.dns_zone_redis.id
+    }
+  }
 }
 ```
-<!-- END_TF_DOCS -->

--- a/azure/redis_cache/local.tf
+++ b/azure/redis_cache/local.tf
@@ -1,9 +1,11 @@
 locals {
+  sequence_suffix = var.sequence_number == null ? "" : "-${format("%03d", var.sequence_number)}"
+
   # Redis Cache naming following standard conventions
-  # Format: redis-{company}-{workload}-{env}-{location}-{seq}
+  # Format: redis-{company}-{workload}-{env}-{location}[-{seq}]
   redis_cache_name = (var.override_name != null ?
     lower(var.override_name) :
-    lower("redis-${var.company_prefix}-${var.workload}-${var.environment}-${var.location}-${format("%03d", var.sequence_number)}")
+    lower("redis-${var.company_prefix}-${var.workload}-${var.environment}-${var.location}${local.sequence_suffix}")
   )
 
   private_endpoint_subresources = ["redisCache"]

--- a/azure/redis_cache/local.tf
+++ b/azure/redis_cache/local.tf
@@ -5,6 +5,8 @@ locals {
     lower(var.override_name) :
     lower("redis-${var.company_prefix}-${var.workload}-${var.environment}-${var.location}-${format("%03d", var.sequence_number)}")
   )
+
+  private_endpoint_subresources = ["redisCache"]
 }
 
 locals {

--- a/azure/redis_cache/main.tf
+++ b/azure/redis_cache/main.tf
@@ -34,14 +34,13 @@ resource "azurerm_redis_cache" "main" {
   lifecycle {
     ignore_changes = [tags]
 
-    ## Naming validation: Ensure either override_name is provided OR all naming components are provided
+    ## Naming validation: Ensure either override_name is provided OR all required naming components are provided
     precondition {
       condition = var.override_name != null || (
         var.workload != null &&
-        var.company_prefix != null &&
-        var.sequence_number != null
+        var.company_prefix != null
       )
-      error_message = "Invalid naming configuration: Either 'override_name' must be provided, or all of 'workload', 'company_prefix', and 'sequence_number' must be provided for automatic naming."
+      error_message = "Invalid naming configuration: Either 'override_name' must be provided, or both 'workload' and 'company_prefix' must be provided for automatic naming."
     }
 
     ## cache_size_in_gb validation

--- a/azure/redis_cache/private_endpoint.tf
+++ b/azure/redis_cache/private_endpoint.tf
@@ -1,0 +1,16 @@
+module "private_endpoint" {
+  source   = "git::github.com/Nmbrs/tf-modules//azure/private_endpoint?ref=f41a116c9f31892191b5e3f146a1e361bfc57322"
+  for_each = toset(local.private_endpoint_subresources)
+
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  resource_settings = {
+    name             = azurerm_redis_cache.main.name
+    resource_id      = azurerm_redis_cache.main.id
+    subresource_name = each.key
+  }
+
+  subnet_id           = var.private_endpoint_settings.subnet_id
+  private_dns_zone_id = var.private_endpoint_settings.private_dns_zone_ids[each.key]
+}

--- a/azure/redis_cache/variables.tf
+++ b/azure/redis_cache/variables.tf
@@ -33,8 +33,9 @@ variable "company_prefix" {
 }
 
 variable "sequence_number" {
-  description = "A numeric value used to ensure uniqueness for resource names."
+  description = "Optional numeric instance counter, zero-padded as `-NNN` suffix. Use only when provisioning multiple Redis caches for the same workload/env/region (e.g., sharding). Omit for the common single-instance case."
   type        = number
+  default     = null
   nullable    = true
 
   validation {

--- a/azure/redis_cache/variables.tf
+++ b/azure/redis_cache/variables.tf
@@ -111,3 +111,13 @@ variable "public_network_access_enabled" {
   default     = false
   nullable    = false
 }
+
+variable "private_endpoint_settings" {
+  description = "Settings for the private endpoint provisioned by this module. `subnet_id` is the resource ID of the subnet where the PEP NIC lands. `private_dns_zone_ids` maps each required subresource to its private DNS zone resource ID."
+  type = object({
+    subnet_id = string
+    private_dns_zone_ids = object({
+      redisCache = string
+    })
+  })
+}


### PR DESCRIPTION
## Description
<!--- Please provide a description of your PR -->
The main goal of this PR is to align redis_cache with the data-tier patterns already adopted by sql_server and service_bus: integrates the private_endpoint module via a consolidated private_endpoint_settings object (subresource redisCache), and makes sequence_number optional (default null) so single-instance callers get a clean name and shards opt in explicitly. Includes the README structural fix so manual content sits outside the BEGIN_TF_DOCS markers and survives future terraform-docs regenerations.
## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [ ] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [ ] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
