### PR TITLE
chore(workspace): bump terraform_version constraint to ~>1.6.0

### DIFF
--- a/terraformcloud/workspace/main.tf
+++ b/terraformcloud/workspace/main.tf
@@ -1,7 +1,7 @@
 resource "tfe_workspace" "workspace" {
   name                = var.name
   organization        = var.organization_name
-  terraform_version   = "~>1.5.0"
+  terraform_version   = "~>1.6.0"
   project_id          = data.tfe_project.project.id
   force_delete        = false
   queue_all_runs      = false


### PR DESCRIPTION
## Summary
- Bump the `terraform_version` constraint on `tfe_workspace` from `~>1.5.0` to `~>1.6.0` so workspaces created by this module run on the 1.6.x line.