### PR TITLE
feature(application_gateway): ignore autoscale_configuration and drop instance count variables

### DIFF
--- a/azure/application_gateway/README.md
+++ b/azure/application_gateway/README.md
@@ -1,21 +1,21 @@
-<!-- BEGIN_TF_DOCS -->
 # Application gateway Module
 
 ## Sumary
 
 The `application_gateway` module enables users to easily provision and configure Azure Application Gateway resources for entry points of traffic and load balancing to the apps. It simplifies the process of setting up Application Gateway, allowing you to define key parameters such as resource name, location, etc all while maintaining infrastructure as code.
 
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, < 2.0.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.117 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.117.1 |
 
 ## Modules
@@ -25,27 +25,28 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_application_gateway.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway) | resource |
+| [azurerm_monitor_diagnostic_setting.app_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_public_ip.application_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_web_application_firewall_policy.application_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_application_firewall_policy) | resource |
 | [azurerm_web_application_firewall_policy.listener](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_application_firewall_policy) | resource |
 | [azurerm_key_vault.certificate](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_secret.certificate](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_log_analytics_workspace.diagnostics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_subnet.app_gw](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_user_assigned_identity.certificate](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_application_backend_settings"></a> [application\_backend\_settings](#input\_application\_backend\_settings) | A list of settings for the application backends that the app gateway will serve. | <pre>list(object({<br/>    routing_rule = object({<br/>      priority = number<br/>    })<br/>    listener = object({<br/>      fqdn             = string<br/>      protocol         = string<br/>      certificate_name = optional(string, null)<br/>    })<br/>    backend = object({<br/>      fqdns                         = list(string)<br/>      port                          = number<br/>      protocol                      = string<br/>      cookie_based_affinity_enabled = optional(bool, false)<br/>      request_timeout_in_seconds    = optional(number, 30)<br/>      health_probe = object({<br/>        timeout_in_seconds             = number<br/>        evaluation_interval_in_seconds = number<br/>        unhealthy_treshold_count       = number<br/>        fqdn                           = string<br/>        path                           = string<br/>        status_codes                   = list(string)<br/>      })<br/>    })<br/>  }))</pre> | `[]` | no |
 | <a name="input_company_prefix"></a> [company\_prefix](#input\_company\_prefix) | Short, unique prefix for the company / organization. | `string` | n/a | yes |
+| <a name="input_diagnostic_settings"></a> [diagnostic\_settings](#input\_diagnostic\_settings) | Diagnostic settings configuration for Application Gateway | <pre>object({<br/>    log_analytics_workspace = object({<br/>      name                = string<br/>      resource_group_name = string<br/>    })<br/><br/>    logs = optional(object({<br/>      access_log_enabled      = bool<br/>      performance_log_enabled = bool<br/>      firewall_log_enabled    = bool<br/>    }))<br/>    metrics_enabled = bool<br/>  })</pre> | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment in which the resource should be provisioned. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Specifies Azure location where the resources should be provisioned. For an exhaustive list of locations, please use the command 'az account list-locations -o table'. | `string` | n/a | yes |
 | <a name="input_managed_identity_settings"></a> [managed\_identity\_settings](#input\_managed\_identity\_settings) | Settings related to the app gateway managed identity used to retrieve SSL certificates. | <pre>object({<br/>    name                = string<br/>    resource_group_name = string<br/>  })</pre> | n/a | yes |
-| <a name="input_max_instance_count"></a> [max\_instance\_count](#input\_max\_instance\_count) | The maximum number of instances the application gateway will have. | `number` | `10` | no |
-| <a name="input_min_instance_count"></a> [min\_instance\_count](#input\_min\_instance\_count) | The minimum number of instances the application gateway will have. | `number` | `2` | no |
 | <a name="input_network_settings"></a> [network\_settings](#input\_network\_settings) | Settings related to the network connectivity of the application gateway. | <pre>object({<br/>    vnet_name                = string<br/>    vnet_resource_group_name = string<br/>    subnet_name              = string<br/>  })</pre> | n/a | yes |
 | <a name="input_override_name"></a> [override\_name](#input\_override\_name) | Optional override for naming logic. | `string` | `null` | no |
 | <a name="input_redirect_listener_settings"></a> [redirect\_listener\_settings](#input\_redirect\_listener\_settings) | A list of settings for the listeners redirection that the app gateway will serve. | <pre>list(object({<br/>    routing_rule = object({<br/>      priority = number<br/>    })<br/>    listener = object({<br/>      fqdn             = string<br/>      protocol         = string<br/>      certificate_name = optional(string, null)<br/>    })<br/>    target = object({<br/>      listener_name        = string<br/>      include_path         = bool<br/>      include_query_string = bool<br/>    })<br/>  }))</pre> | `[]` | no |
@@ -58,12 +59,13 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_id"></a> [id](#output\_id) | The application gateway ID. |
 | <a name="output_name"></a> [name](#output\_name) | The application gateway full name. |
 | <a name="output_public_ip_address"></a> [public\_ip\_address](#output\_public\_ip\_address) | The public IP address of the application gateway. |
 | <a name="output_public_ip_fqdn"></a> [public\_ip\_fqdn](#output\_public\_ip\_fqdn) | The public IP FQDN of the application gateway. |
 | <a name="output_workload"></a> [workload](#output\_workload) | The application gateway workload name. |
+<!-- END_TF_DOCS -->
 
 ## How to use it?
 
@@ -80,8 +82,6 @@ module "application_gateway" {
   environment         = "dev"
   location            = "westeurope"
   resource_group_name = "rg-contoso-dev"
-  min_instance_count  = 2
-  max_instance_count  = 10
 
   network_settings = {
     vnet_name                = "vnet-contoso-dev"
@@ -182,8 +182,6 @@ module "application_gateway" {
   environment         = "prod"
   location            = "westeurope"
   resource_group_name = "rg-contoso-prod"
-  min_instance_count  = 2
-  max_instance_count  = 10
 
   network_settings = {
     vnet_name                = "vnet-contoso-prod"
@@ -261,8 +259,6 @@ module "application_gateway" {
   environment         = "dev"
   location            = "westeurope"
   resource_group_name = "rg-contoso-dev"
-  min_instance_count  = 2
-  max_instance_count  = 10
 
   network_settings = {
     vnet_name                = "vnet-contoso-dev"
@@ -343,8 +339,6 @@ module "application_gateway" {
   environment         = "dev"
   location            = "westeurope"
   resource_group_name = "rg-contoso-dev"
-  min_instance_count  = 2
-  max_instance_count  = 10
 
  network_settings = {
     vnet_name                = "vnet-contoso-dev"
@@ -461,8 +455,6 @@ module "application_gateway" {
   environment         = "prod"
   location            = "westeurope"
   resource_group_name = "rg-contoso-prod"
-  min_instance_count  = 2
-  max_instance_count  = 20
 
   network_settings = {
     vnet_name                = "vnet-contoso-prod"
@@ -505,4 +497,3 @@ module "application_gateway" {
   }
 }
 ```
-<!-- END_TF_DOCS -->

--- a/azure/application_gateway/local.tf
+++ b/azure/application_gateway/local.tf
@@ -54,6 +54,15 @@ locals {
 }
 
 locals {
+  # Autoscale bounds applied only when the gateway is first created.
+  # Afterwards the capacity is owned by an external process, so the
+  # autoscale_configuration block is ignored by the lifecycle rules and these
+  # values have no effect on already deployed gateways.
+  initial_min_instance_count = 2
+  initial_max_instance_count = 10
+}
+
+locals {
   # FQDN to resource name transformation
   # Transforms FQDNs to valid Azure resource names by:
   # - Replacing dots with hyphens

--- a/azure/application_gateway/main.tf
+++ b/azure/application_gateway/main.tf
@@ -95,9 +95,12 @@ resource "azurerm_application_gateway" "main" {
     tier = "WAF_v2"
   }
 
+  # Bounds are seeded on creation only. The block is required because v2 SKUs
+  # must declare either autoscale_configuration or sku.capacity, but its values
+  # are ignored on subsequent applies (see lifecycle block below).
   autoscale_configuration {
-    min_capacity = var.min_instance_count
-    max_capacity = var.max_instance_count
+    min_capacity = local.initial_min_instance_count
+    max_capacity = local.initial_max_instance_count
   }
 
   identity {
@@ -346,6 +349,9 @@ resource "azurerm_application_gateway" "main" {
     ignore_changes = [
       tags,
       waf_configuration,
+      # Instance counts are managed by an external process after creation.
+      # Terraform seeds the initial bounds and then stops tracking them.
+      autoscale_configuration,
       # Rewrite rules within each set are managed by an external process.
       # Terraform manages the empty rewrite_rule_set (name and lifecycle) but must
       # not overwrite the rewrite_rule entries populated externally.
@@ -453,12 +459,6 @@ resource "azurerm_application_gateway" "main" {
       rewrite_rule_set[98].rewrite_rule,
       rewrite_rule_set[99].rewrite_rule,
     ]
-
-    ## Instance count validation
-    precondition {
-      condition     = var.min_instance_count <= var.max_instance_count
-      error_message = format("Invalid configuration: minimum instance count (%s) must be less than or equal to maximum instance count (%s).", var.min_instance_count, var.max_instance_count)
-    }
 
     ## Naming validation: Ensure either override_name is provided OR all naming components are provided
     precondition {

--- a/azure/application_gateway/variables.tf
+++ b/azure/application_gateway/variables.tf
@@ -201,30 +201,6 @@ variable "ssl_certificates" {
   nullable = false
 }
 
-variable "min_instance_count" {
-  description = "The minimum number of instances the application gateway will have."
-  type        = number
-  default     = 2
-  nullable    = false
-
-  validation {
-    condition     = var.min_instance_count >= 1 && var.min_instance_count <= 100
-    error_message = format("Invalid value '%s' for variable 'min_instance_count', it must be between 1 and 100.", var.min_instance_count)
-  }
-}
-
-variable "max_instance_count" {
-  description = "The maximum number of instances the application gateway will have."
-  type        = number
-  default     = 10
-  nullable    = false
-
-  validation {
-    condition     = var.max_instance_count >= 1 && var.max_instance_count <= 100
-    error_message = format("Invalid value '%s' for variable 'max_instance_count', it must be between 1 and 100.", var.max_instance_count)
-  }
-}
-
 variable "diagnostic_settings" {
   description = "Diagnostic settings configuration for Application Gateway"
   type = object({


### PR DESCRIPTION
The main goal of this PR is to hand ownership of the Application Gateway instance counts over to external tooling. The min_instance_count and max_instance_count variables are removed and replaced by two locals that seed the auto-scale bounds only when the gateway is first created, keeping the previous default values of 2 and 10 so already deployed gateways see no drift. The whole autoscale_configuration block is then added to ignore_changes, so Terraform stops reverting capacity changes made outside of it; the block still has to be declared because v2 SKUs require either autoscale_configuration or sku.capacity, and ignore_changes does not affect resource creation.
  
## Description
<!--- Please provide a description of your PR -->

## PR Checklist

Please ensure the following before submitting this PR:
<!-- Please check all the following options that apply using 'X'. -->

- [X] You complied with the code style of this project.
- [X] You formatted all Terraform configuration files to a canonical format (Hint: `terraform fmt`).
- [X] You validated all Terraform configuration files (Hint: `terraform validate`).
- [X] You executed a speculative plan, showing what actions Terraform would take to apply the current configuration (Hint: `terraform plan`).
- [X] The documentation was updated (`README.md`, `CHANGELOG.md`, etc.).
- [X] Whenever possible, the dependencies were updated to the latest compatible versions.

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [ ] Bugfix.
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no interface changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes.
- [ ] Other... Please describe:

### What is the new behavior?
<!-- Please describe the behavior that you are modifying / creating. -->

### How to test it
<!-- Please describe how to test it. -->

### Does this PR introduce a breaking change?
<!-- Please mark all the following options that apply with a 'X'. -->

- [ ] Yes.
- [X] No.

### Other information
<!-- You can add here any additional information to this PR. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications here. -->
